### PR TITLE
JR2-150 Manage releases by defining Github release tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,6 @@ script:
 after_success:
 - bash <(curl -s https://codecov.io/bash)
 before_deploy:
-- "./gradlew bootJar publish -Pprod -Pgraphite -Pprometheus -x test --stacktrace"
 - chmod +x .travis/deploy.sh
 deploy:
 - provider: script
@@ -46,6 +45,11 @@ deploy:
   on:
     all_branches: true
     condition: "$TRAVIS_BRANCH =~ ^release.*$"
+- provider: script
+  skip_cleanup: true
+  script: "./gradlew bootJar publish -Pprod -Pgraphite -Pprometheus -Pversion=${TRAVIS_TAG} -x test --stacktrace"
+  on:
+    tags: true
 after_deploy:
 -  sleep 90 && baseURL=http://159.100.254.166:8080 ./gradlew -b e2e.gradle gatlingRunAll --stacktrace
 notifications:

--- a/.travis/deploy.sh
+++ b/.travis/deploy.sh
@@ -1,3 +1,6 @@
+#!/usr/bin/env bash
+echo 'publish to Artifactory'
+./gradlew bootJar publish -Pprod -Pgraphite -Pprometheus -x test --stacktrace
 echo 'prepare SSH connection'
 chmod 600 .travis/ssh_key
 ssh-keygen -p -P $SSH_PASS -N '' -f .travis/ssh_key

--- a/build.gradle
+++ b/build.gradle
@@ -128,7 +128,7 @@ if (project.hasProperty('zipkin')) {
 }
 
 group = 'ch.admin.seco.service.reference'
-version = '0.0.2-SNAPSHOT'
+version = version != 'unspecified' ? version : '0.0.3-SNAPSHOT'
 
 description = ''
 


### PR DESCRIPTION
This is a proposal to create Releases.

With this solution we can use can use the github release feature to create releases via github ui. the build will use the github release tag as project version. for development and deployment to "dev" we can use static SNAPSHOTS and don't really need individual versions